### PR TITLE
Remove Healthcheck variable

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -23,7 +23,6 @@ function Invoke-AsBuiltReport.VMware.vSphere {
     )
 
     $InfoLevel = $Global:ReportConfig.InfoLevel
-    $Healthcheck = $Global:ReportConfig.$Healthcheck
 
     # If custom style not set, use default style
     if (!$StylePath) {


### PR DESCRIPTION
- Remove $healthcheck variable from the VMware vSphere function. It is not required as the $Global:Healthcheck variable is defined in New-AsBuiltReport