### PR TITLE
Remove `requires` from Invoke-AsBuiltReport.VMware.vSphere function

### DIFF
--- a/AsBuiltReport.VMware.vSphere.psd1
+++ b/AsBuiltReport.VMware.vSphere.psd1
@@ -1,10 +1,10 @@
 @{
     RootModule = 'AsBuiltReport.VMware.vSphere.psm1'
-    ModuleVersion = '0.4.0'
+    ModuleVersion = '0.4.1'
     GUID = 'e1cbf1ce-cf01-4b6e-9cc2-56323da3c351'
     Author = 'Tim Carman'
     Copyright = '(c) 2018 Tim Carman. All rights reserved.'
-    Description = 'A PowerShell module to generate as built reports on the configuration of datacentre infrastucture.'
+    Description = 'A PowerShell module to generate an as built report on the configuration of VMware vSphere'
     PowerShellVersion = '4.0'
     DotNetFrameworkVersion = '4.5'
 
@@ -15,7 +15,7 @@
 
         PSData = @{
             Tags = @('AsBuiltReport', 'Report', 'VMware', 'vSphere', 'Documentation', 'PScribo')
-            LicenseUri = 'https://raw.githubusercontent.com/AsBuiltReport/AsBuiltReport,VMware.vSphere/master/LICENSE'
+            LicenseUri = 'https://raw.githubusercontent.com/AsBuiltReport/AsBuiltReport.VMware.vSphere/master/LICENSE'
             ProjectUri = 'https://github.com/AsBuiltReport/AsBuiltReport.VMware.vSphere'
             # IconUri = ''
             # ReleaseNotes = ''

--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -1,13 +1,11 @@
 function Invoke-AsBuiltReport.VMware.vSphere {
-    #requires -Modules @{ModuleName="PScribo";ModuleVersion="0.7.24"},AsBuiltReport,VMware.VimAutomation.Core,VMware.VumAutomation
-    
     <#
     .SYNOPSIS  
         PowerShell script to document the configuration of VMware vSphere infrastucture in Word/HTML/XML/Text formats
     .DESCRIPTION
         Documents the configuration of VMware vSphere infrastucture in Word/HTML/XML/Text formats using PScribo.
     .NOTES
-        Version:        0.4.0
+        Version:        0.4.1
         Author:         Tim Carman
         Twitter:        @tpcarman
         Github:         tpcarman


### PR DESCRIPTION
## Description
- Remove `requires` from Invoke-AsBuiltReport.VMware.vSphere function
- Correct LicenseUri link in module manifest