### PR TITLE
Fix for issue #17 - ESXi Host Datastore Specifications

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -1830,24 +1830,26 @@ function Invoke-AsBuiltReport.VMware.vSphere {
                 
                                         #region ESXi Host Datastore Specifications
                                         Section -Style Heading5 'Datastores' {
-                                            $VMHostDatastores = $VMHost | Get-Datastore          
-                                            $VMHostDsSpecs = foreach ($VMHostDatastore in $VMHostDatastores) {
-                                                [PSCustomObject]@{
-                                                    'Name' = $VMHostDatastore.Name
-                                                    'Type' = $VMHostDatastore.Type
-                                                    'Version' = $VMHostDatastore.FileSystemVersion
-                                                    '# of VMs' = $VMHostDatastore.ExtensionData.VM.Count
-                                                    'Total Capacity GB' = [math]::Round($VMHostDatastore.CapacityGB, 2)
-                                                    'Used Capacity GB' = [math]::Round((($VMHostDatastore.CapacityGB) - ($VMHostDatastore.FreeSpaceGB)), 2)
-                                                    'Free Space GB' = [math]::Round($VMHostDatastore.FreeSpaceGB, 2)
-                                                    '% Used' = [math]::Round((100 - (($VMHostDatastore.FreeSpaceGB) / ($VMHostDatastore.CapacityGB) * 100)), 2)
+                                            $VMHostDatastores = $VMHost | Get-Datastore
+                                            if ($VMHostDatastores) {        
+                                                $VMHostDsSpecs = foreach ($VMHostDatastore in $VMHostDatastores) {
+                                                    [PSCustomObject]@{
+                                                        'Name' = $VMHostDatastore.Name
+                                                        'Type' = $VMHostDatastore.Type
+                                                        'Version' = $VMHostDatastore.FileSystemVersion
+                                                        '# of VMs' = $VMHostDatastore.ExtensionData.VM.Count
+                                                        'Total Capacity GB' = [math]::Round($VMHostDatastore.CapacityGB, 2)
+                                                        'Used Capacity GB' = [math]::Round((($VMHostDatastore.CapacityGB) - ($VMHostDatastore.FreeSpaceGB)), 2)
+                                                        'Free Space GB' = [math]::Round($VMHostDatastore.FreeSpaceGB, 2)
+                                                        '% Used' = [math]::Round((100 - (($VMHostDatastore.FreeSpaceGB) / ($VMHostDatastore.CapacityGB) * 100)), 2)
+                                                    }
                                                 }
+                                                if ($Healthcheck.Datastore.CapacityUtilization) {
+                                                    $VMHostDsSpecs | Where-Object {$_.'% Used' -ge 90} | Set-Style -Style Critical
+                                                    $VMHostDsSpecs | Where-Object {$_.'% Used' -ge 75 -and $_.'% Used' -lt 90} | Set-Style -Style Warning
+                                                }
+                                                $VMHostDsSpecs | Sort-Object Name | Table -Name "$VMHost Datastores" #-ColumnWidths 20,10,10,10,10,10,10,10,10
                                             }
-                                            if ($Healthcheck.Datastore.CapacityUtilization) {
-                                                $VMHostDsSpecs | Where-Object {$_.'% Used' -ge 90} | Set-Style -Style Critical
-                                                $VMHostDsSpecs | Where-Object {$_.'% Used' -ge 75 -and $_.'% Used' -lt 90} | Set-Style -Style Warning
-                                            }
-                                            $VMHostDsSpecs | Sort-Object Name | Table -Name "$VMHost Datastores" #-ColumnWidths 20,10,10,10,10,10,10,10,10
                                         }
                                         #endregion ESXi Host Datastore Specifications
                 


### PR DESCRIPTION
Addresses issues where the VMware vSphere errors out if an ESXi host does not have any datastores.

## Description
Addresses issues where the VMware vSphere errors out if an ESXi host does not have any datastores.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Issue #17

## Motivation and Context
Resolve issues with VMware vSphere reporting

## How Has This Been Tested?
Tested against production environment, which includes a vSAN witness host which does not have storage attached.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
