### PR TITLE
Fixed Issue 33 - Unable to retrieve PCIe device information on some VMHosts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VMware vSphere As Built Report Changelog
 
+## [1.0.8] - 2019-07-25
+### Changed
+- Fixed issue 33 - Unable to retrieve PCIe device information on some VMHosts.
+
 ## [1.0.7] - 2019-06-21
 ### Changed
 - Fixed font in default VMware style

--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -428,7 +428,7 @@ function Invoke-AsBuiltReport.VMware.vSphere {
     .PARAMETER esxcli
     Esxcli session object associated to the host.
     .EXAMPLE
-    $Credentials = Get-Credentials
+    $Credentials = Get-Credential
     $Server = Connect-VIServer -Server vcenter01.example.com -Credentials $Credentials
     $VMHost = Get-VMHost -Server $Server -Name esx01.example.com
     $esxcli = Get-EsxCli -Server $Server -VMHost $VMHost -V2


### PR DESCRIPTION
Fixed Issue 33 - Unable to retrieve PCIe device information on some VMHosts.

## Description
Added check to skip over vmnic's used for FCoE in Get-PciDeviceDetail

## Related Issue
https://github.com/AsBuiltReport/AsBuiltReport.VMware.vSphere/issues/33

## Motivation and Context
To fix issue when running on hosts with FCoE

## How Has This Been Tested?
Ran on HP ProLiant BL460c with Broadcom Corporation QLogic 57840 10 Gigabit Ethernet Adapter

## Screenshots (if appropriate):
none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
