### PR TITLE
extra filter pciDevices - ModuleName != None

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -493,7 +493,7 @@ function Invoke-AsBuiltReport.VMware.vSphere {
                 Name = "N/A"
                 Version = "N/A"
             }
-            $pciDevices = $esxcli.hardware.pci.list.Invoke() | Where-Object { $_.VMkernelName -like "vmhba*" -or $_.VMkernelName -like "vmnic*" -or $_.VMkernelName -like "vmgfx*" } | Sort-Object -Property VMkernelName 
+            $pciDevices = $esxcli.hardware.pci.list.Invoke() | Where-Object { $_.VMkernelName -match 'vmhba|vmnic|vmgfx' -and $_.ModuleName -ne 'None'} | Sort-Object -Property VMkernelName 
             $nicList = $esxcli.network.nic.list.Invoke() | Sort-Object Name
             #$fcoeAdapterList = $esxcli.fcoe.adapter.list.Invoke().PhysicalNIC # Get list of vmnics used for FCoE, because we don't want those vmnics here.
             foreach ($pciDevice in $pciDevices) {


### PR DESCRIPTION
## Description
The original code allowed a pciDevices to have a ModuleName equals to 'None' which breaks the rest of the code and stop the whole script. 

## Motivation and Context

This paticular host has a 'LOM' SFP+ card which is not connected at the moment. Here is what can be reported from the console. The device is physcally installed but the module not loaded.

 esxcli hardware pci list | grep 'vmnic0' -A23
   VMkernel Name: **vmnic0**
   Vendor Name: Intel(R)
   Device Name: Ethernet Connection X722
   Configured Owner: VMkernel
   Current Owner: VMkernel
   Vendor ID: 0x8086
   Device ID: 0x37cc
   SubVendor ID: 0x17aa
   SubDevice ID: 0x4021
   Device Class: 0x0200
   Device Class Name: Ethernet controller
   Programming Interface: 0x00
   Revision ID: 0x09
   Interrupt Line: 0x0b
   IRQ: 255
   Interrupt Vector: 0x00
   PCI Pin: 0x00
   Spawned Bus: 0x00
   Flags: 0x3201
   Module ID: -1
   Module Name: **None**
   Chassis: 0
   Physical Slot: 4294967295
   Slot Description: em1

 esxcli hardware pci list | grep 'vmnic1' -A 23
   VMkernel Name: **vmnic1**
   Vendor Name: Broadcom Corporation
   Device Name: NetXtreme BCM5720 Gigabit Ethernet
   Configured Owner: VMkernel
   Current Owner: VMkernel
   Vendor ID: 0x14e4
   Device ID: 0x165f
   SubVendor ID: 0x17aa
   SubDevice ID: 0x402c
   Device Class: 0x0200
   Device Class Name: Ethernet controller
   Programming Interface: 0x00
   Revision ID: 0x00
   Interrupt Line: 0x0b
   IRQ: 255
   Interrupt Vector: 0x37
   PCI Pin: 0x00
   Spawned Bus: 0x00
   Flags: 0x3201
   Module ID: 20
   Module Name: **ntg3**


## How Has This Been Tested?
Yes, script doesn't stop.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
