### PR TITLE
Remove required to VMware.PowerCLI on psd1 file

### DIFF
--- a/AsBuiltReport.VMware.vSphere.psd1
+++ b/AsBuiltReport.VMware.vSphere.psd1
@@ -52,10 +52,6 @@
         @{
             ModuleName = 'AsBuiltReport.Core';
             ModuleVersion = '1.1.0'
-        },
-        @{
-            ModuleName = 'VMware.PowerCLI';
-            ModuleVersion = '12.3.0'
         }
     )
 


### PR DESCRIPTION
It don't work with PowerShell core (on Windows.... )

Because all module are not yet compatible with PowerShell core, and you get following exception :
Exception: The VMware.ImageBuilder module is not currently supported on the Core edition of PowerShell