### PR TITLE
Rewrite of 'ESXi Host PCI Devices'

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.vSphere.ps1
@@ -1934,7 +1934,6 @@ function Invoke-AsBuiltReport.VMware.vSphere {
                                                 Create an array with PCI Address and VMware Devices (vmnic,vmhba,?vmgfx?) 
                                                 #>
                                                 $PciToDeviceMapping = @{}
-                                                
                                                 $NetworkAdapters  = Get-VMHostNetworkAdapter -VMHost $VMHost -Physical
                                                 foreach ($adapter in $NetworkAdapters) {
                                                     $PciToDeviceMapping[$adapter.PciId] = $adapter.DeviceName
@@ -1943,7 +1942,6 @@ function Invoke-AsBuiltReport.VMware.vSphere {
                                                 foreach ($adapter in $hbAdapters) {
                                                     $PciToDeviceMapping[$adapter.Pci] = $adapter.Device
                                                 }
-                                                
                                                 <# Data Object - HostGraphicsInfo(vim.host.GraphicsInfo)
                                                 This function has been available since version 5.5, but we can't be sure if it is still valid.
                                                 I don't have access to a vGPU-enabled system.


### PR DESCRIPTION
VMware has deprecated the capability of gathering PCI Devices information using the Get-EsxCli -v2 command, thereby impacting the script.
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rewrite the original function and use instead Get-VMHostNetworkAdapter, Get-VMHostHba and Get-VMHostPciDevice cmdlets to achieve the same output minus 'Slot Description'
Device Class is now reported as 

'MassStorage' = Block
'Network'  = Ethernet
'Display' =  ?????
'SerialBusController' = FiberAdapter

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#111 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not compatible with version 8 and subsequent releases.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
PowerCLI 13.1 and vSphere 7U3f, should work on release 8
I don't have access to a GPU.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
